### PR TITLE
project.nameを"tensorflow-addons"に

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "tensorflow-addons-subset"
+name = "tensorflow-addons"
 description = "A subset of tensorflow-addons which only has the functions used in repositories owned by Geotrans."
 version = "0.25.0"
 readme = "README.md"


### PR DESCRIPTION
Macでは、本家のaddonsがinstallできないので、本家のaddonsと同等のものとしてpackage managerに認識させる必要がある。そこでnameを本家と一致させたら、一括でpip installができた。

他に問題がなければこれでいきたい。